### PR TITLE
Issue #13804 Fix

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -261,6 +261,8 @@ def delete_older_backups(dropbox_client, folder_path, to_keep):
 	for f in res.entries:
 		if isinstance(f, dropbox.files.FileMetadata) and 'sql' in f.name:
 			files.append(f)
+		if isinstance(f, dropbox.files.FileMetadata) and 'json' in f.name: 
+ 			files.append(f)
 
 	if len(files) <= to_keep:
 		return


### PR DESCRIPTION
fix(Dropbox Integration): Remove old json metadata in addition to old sql metadata.

Add lines 264 & 265 to remove json metadata in addition to sql metadata in dropbox_settings.py delete_older_backups() function:

Fixes frappe/offsite_backups#13


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
